### PR TITLE
🐛 修复插件第一次安装后无法生成部分默认配置文件的问题

### DIFF
--- a/components/YamlReader.js
+++ b/components/YamlReader.js
@@ -77,8 +77,9 @@ export default class YamlReader {
 
   save() {
     const yaml = this.document.toString()
-    // 数据不变不写💩
-    if (yaml === this.data) return
+    // 比较前检查文件是否存在，数据不变不写💩，比较前去除多余换行
+    const fileExists = fs.existsSync(this.yamlPath)
+    if (yaml.trim() === this.data.trim() && fileExists) return
     this.isSave = true
     fs.writeFileSync(this.yamlPath, yaml, "utf8")
   }


### PR DESCRIPTION
如图所示，目前存在首次运行时配置文件无法正常创建的问题
<img width="1245" alt="image" src="https://github.com/user-attachments/assets/83e18b38-665d-457d-9298-0edd70aa9917" />
问题出现在`YamlReader.js`的`save()`，没有忽略换行就比较内容是否相等，导致事实上无论是否更改，条件都不满足，继续向下执行保存，而`CodeUpdate.yaml`因为最后为空List，结果反而最后没有`\n`，满足了`if (yaml === this.data) return`的条件，所以被跳过保存。
比较好笑