### PR TITLE
fix: 联系主人 冷却时间

### DIFF
--- a/src/apps/sendMaster.ts
+++ b/src/apps/sendMaster.ts
@@ -44,7 +44,8 @@ export class sendMasterMsg extends plugin {
     if (Sending) return e.reply('❎ 已有发送任务正在进行中，请等待上一条完成后重试')
     const { open, cd, BotId, banWords, banUser, banGroup, MsgTemplate, successMsgTemplate, failsMsgTemplate, Master } = Config.sendMaster
     const REDISCDKEY = `${REDISKEY}:cd`
-    const cdTime = Number(cd) || 0
+    const rawCd = Number(cd)
+    const cdTime = Number.isFinite(rawCd) ? Math.max(0, Math.trunc(rawCd)) : 0
     if (!e.isMaster) {
       if (!open) return e.reply('❎ 该功能暂未开启，请先让主人开启才能用哦', true)
       if (cdTime > 0) {

--- a/src/apps/sendMaster.ts
+++ b/src/apps/sendMaster.ts
@@ -47,12 +47,12 @@ export class sendMasterMsg extends plugin {
     const cdTime = Number(cd) || 0
     if (!e.isMaster) {
       if (!open) return e.reply('❎ 该功能暂未开启，请先让主人开启才能用哦', true)
-      if (cdTime > 0 && await redis.get(REDISCDKEY)) {
+      if (cdTime > 0) {
         const ttl = await redis.ttl(REDISCDKEY)
-        if (ttl === -1) {
-          await redis.del(REDISCDKEY)
-        } else if (ttl > 0) {
+        if (ttl > 0) {
           return e.reply('❎ 操作频繁，请稍后再试', true)
+        } else if (ttl === -1) {
+          await redis.del(REDISCDKEY)
         }
       }
       if (banWords.some(item => e.msg.includes(item))) return e.reply('❎ 消息包含违禁词，请检查后重试', true)

--- a/src/apps/sendMaster.ts
+++ b/src/apps/sendMaster.ts
@@ -44,9 +44,17 @@ export class sendMasterMsg extends plugin {
     if (Sending) return e.reply('❎ 已有发送任务正在进行中，请等待上一条完成后重试')
     const { open, cd, BotId, banWords, banUser, banGroup, MsgTemplate, successMsgTemplate, failsMsgTemplate, Master } = Config.sendMaster
     const REDISCDKEY = `${REDISKEY}:cd`
+    const cdTime = Number(cd) || 0
     if (!e.isMaster) {
       if (!open) return e.reply('❎ 该功能暂未开启，请先让主人开启才能用哦', true)
-      if (cd !== 0 && await redis.get(REDISCDKEY)) return e.reply('❎ 操作频繁，请稍后再试', true)
+      if (cdTime > 0 && await redis.get(REDISCDKEY)) {
+        const ttl = await redis.ttl(REDISCDKEY)
+        if (ttl === -1) {
+          await redis.del(REDISCDKEY)
+        } else if (ttl > 0) {
+          return e.reply('❎ 操作频繁，请稍后再试', true)
+        }
+      }
       if (banWords.some(item => e.msg.includes(item))) return e.reply('❎ 消息包含违禁词，请检查后重试', true)
       if (banUser.includes(e.user_id)) return e.reply('❎ 对不起，您不可用', true)
       if (e.isGroup && banGroup.includes(e.group_id)) return e.reply('❎ 该群暂不可用该功能', true)
@@ -80,7 +88,7 @@ export class sendMasterMsg extends plugin {
       const Ret = await utils.sendMasterMsg(msg, Bot[BotId]?.uin || e.self_id, mode, Master)
       const successMsg = utils.parseTemplate(successMsgTemplate, { masterQQ: Object.values(Ret).flatMap(group => Object.keys(group)).toString() })
       await e.reply(successMsg)
-      if (REDISCDKEY) await redis.set(REDISCDKEY, '1')
+      if (!e.isMaster && cdTime > 0) await redis.set(REDISCDKEY, '1', { EX: cdTime })
       await redis.set(`${REDISKEY}:${msgId}`, JSON.stringify(redisData), { EX: 86400 })
     } catch (err) {
       const msg = utils.parseTemplate(failsMsgTemplate, { masterQQ: String(Config.masterQQ[0]) })

--- a/src/modules/guoba/schemas/sendMaster.ts
+++ b/src/modules/guoba/schemas/sendMaster.ts
@@ -19,7 +19,7 @@ export const sendMaster: GuobaSchemas = [
     component: 'InputNumber',
     required: true,
     componentProps: {
-      min: 1,
+      min: 0,
       placeholder: '请输入冷却时间'
     }
   },


### PR DESCRIPTION
refactor(cooldown): 支持通过 0 禁用冷却机制并修复 Redis 脏数据拦截问题

- 统一将 CD 时间数字化，并将 0 视为禁用（仅在 cdTime > 0 时触发校验）
- 增强 Redis TTL 检查：若 TTL 为 -1（残留脏数据）则直接删除，若 > 0 则正常拦截
- 仅对非 Master 用户写入冷却 Key，并以 cdTime 作为 EX 过期时间
- 更新 sendMaster Schema，将 min 限制从 1 调整为 0

解决了因 Redis 死键导致的误报问题，同时提供了关闭 CD 机制的能力。

## Summary by Sourcery

Adjust send-master message cooldown handling and configuration to allow disabling cooldowns and to avoid stale Redis key interference.

Bug Fixes:
- Prevent stale Redis cooldown keys with infinite TTL from incorrectly blocking message sends by deleting them before enforcing rate limits.

Enhancements:
- Treat cooldown value 0 as disabling cooldown checks and only set cooldown when configured with a positive duration.
- Store cooldown keys in Redis with an expiration equal to the configured cooldown time instead of using non-expiring keys.
- Avoid writing cooldown keys for master users while still enforcing cooldowns for non-master users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了冷却时间的检测逻辑，提高判断准确性和异常处理能力
  * 调整冷却配置，现在支持将冷却时间设置为0秒

<!-- end of auto-generated comment: release notes by coderabbit.ai -->